### PR TITLE
Remove ember-invoke-action as a dependency

### DIFF
--- a/addon/components/ember-timepicker.js
+++ b/addon/components/ember-timepicker.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/ember-timepicker';
-import { InvokeActionMixin } from 'ember-invoke-action';
 
 const { TextField, assign } = Ember;
 
-export default TextField.extend(InvokeActionMixin, {
+export default TextField.extend({
   layout,
 
   classNames: ['ember-timepicker'],
@@ -12,12 +11,15 @@ export default TextField.extend(InvokeActionMixin, {
   timepicker: null,
   options: {},
 
+  // Noop onChange method
+  onChange() {},
+
   didInsertElement() {
     this._super(...arguments);
 
     // Connect the `onChange` action to this library's `change` event.
     const options = assign({
-      change: (...args) => this.invokeAction('onChange', ...args)
+      change: (...args) => this.onChange(...args)
     }, this.get('options'));
 
     // Create a new instance of the timepicker.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "1.1.1",
     "ember-cli-node-assets": "0.1.6",
-    "ember-invoke-action": "1.4.0",
     "jquery-timepicker": "^1.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I've tested these change locally in my codebase since there are no tests :/ Feel free to verify things work the same and let me know if I messed anything up. I don't have much knowledge around the `ember-invoke-action` addon. fixes #2